### PR TITLE
BUG: La ultima version causa que las annotations no persistan

### DIFF
--- a/src/lib/Editor/Editor.js
+++ b/src/lib/Editor/Editor.js
@@ -392,8 +392,8 @@ const WrappedEditor = ({
       return store.subscribe(() => {
         const prevD = currentD;
         const prevNa = currentNa;
-        currentNa = store.getState().anonymizer.newAnnotations;
-        currentD = store.getState().anonymizer.deleteAnnotations;
+        currentNa = store.getState().anonymizer.present.newAnnotations;
+        currentD = store.getState().anonymizer.present.deleteAnnotations;
         if (prevD !== currentD || prevNa !== currentNa) {
           onAnnotationsChange(currentD, currentNa);
         }


### PR DESCRIPTION
## Descripción

#### Las annotations manuales que se realizan desde la app no se persisten en el documento final anonimizado.

La libreria ahora utiliza `redux-undo` y eso cambia el formato del `state` de:
```
state.anonymizer.newAnnotations
state.anonymizer.deleteAnnotations
```
por:
```
state.anonymizer.present.newAnnotations
state.anonymizer.present.deleteAnnotations
```
Esto causa que las annotations sean siempre `undefined`, el servidor nunca las recibe y por ende nunca se guardan.
Falta realizar ese ajuste en algunos lugares mas del codigo.


Closes https://github.com/instituciones-abiertas/ia2-annotation-tool/issues/22


## Tipo de cambio

- [x] Fix de bug (non-breaking change que resuelve un issue)

## ¿Cómo se ha probado?

Localmente levantando la desktop app.
De hecho, son los mismos cambios que ejecuta el quick fix aplicado en:
https://github.com/instituciones-abiertas/ia2-desktop-app/pull/4

La idea seria actualizar ese PR una vez se haya lanzado una nueva version de `ia2-annotation-tool`.

**Resultado esperado:** El usuario de la desktop app guarde correctamente sus annotations en el documento anonimizado.


## Lista de Verificación

- [x] **He realizado una autoevaluación de mi propio código.**
- [ ] He comentado mi código, especialmente en áreas difíciles de entender.
- [ ] He realizado los cambios correspondientes a mis cambios en la documentación.
- [ ] **Mis cambios no generan nuevas advertencias.**
- [ ] He añadido pruebas que prueban que mi bugfix es eficaz o que mi feature funciona.
